### PR TITLE
Handle failing Zod number validations 

### DIFF
--- a/src/routes/inventory.ts
+++ b/src/routes/inventory.ts
@@ -13,6 +13,7 @@ import {
   updateInventoryItem,
 } from "../services/inventory";
 import { InventoryPage } from "../components/pages/inventory";
+import { RequestNumberSchema } from "../services/common/constants";
 
 const inventorySchemas = {
   searchInventoryItemsQuery: z.object({
@@ -20,11 +21,11 @@ const inventorySchemas = {
   }),
   createInventoryItemBody: z.object({
     name: z.string(),
-    price: z.number(),
+    price: RequestNumberSchema,
   }),
   updateInventoryItemBody: z.object({
     name: z.string(),
-    price: z.number(),
+    price: RequestNumberSchema,
   }),
 };
 

--- a/src/routes/order.ts
+++ b/src/routes/order.ts
@@ -15,32 +15,35 @@ import {
 } from "../services/orders";
 import { ViewOrdersSection } from "../components/pages/orders/orders";
 import { PaymentTypes } from "../postgres/common/constants";
-import { ServerHxTriggerEvents } from "../services/common/constants";
+import {
+  RequestNumberSchema,
+  ServerHxTriggerEvents,
+} from "../services/common/constants";
 
 const orderSchema = {
   activeOrdersParams: z.object({
-    orderId: z.number(),
+    orderId: RequestNumberSchema,
   }),
   resumeOrderParams: z.object({
-    orderId: z.number(),
+    orderId: RequestNumberSchema,
   }),
   confirmOrderParams: z.object({
-    orderId: z.number(),
-    paymentId: z.number(),
+    orderId: RequestNumberSchema,
+    paymentId: RequestNumberSchema,
   }),
   updateItemCounterParams: z.object({
-    itemId: z.number(),
+    itemId: RequestNumberSchema,
     updateType: z.string().length(3),
   }),
   addOrRemoveItemParams: z.object({
-    orderId: z.number(),
-    inventoryId: z.number(),
+    orderId: RequestNumberSchema,
+    inventoryId: RequestNumberSchema,
   }),
   updatePaymentTypeForOrderBody: z.object({
     paymentType: z.nativeEnum(PaymentTypes),
   }),
   updatePaymentTypeForOrderParams: z.object({
-    paymentId: z.number(),
+    paymentId: RequestNumberSchema,
   }),
 };
 

--- a/src/services/common/constants.ts
+++ b/src/services/common/constants.ts
@@ -1,3 +1,6 @@
+import { z } from "zod";
+import { parseNumber } from "./utils";
+
 /**
  * Contains commands that will trigger actions on the front end once an API request has been completed.
  */
@@ -11,3 +14,5 @@ export const CookieConstansts = {
   maxAge: 60 * 3,
   path: "/;/auth;/root",
 } as const;
+
+export const RequestNumberSchema = z.string().transform(parseNumber).optional();

--- a/src/services/common/constants.ts
+++ b/src/services/common/constants.ts
@@ -15,4 +15,4 @@ export const CookieConstansts = {
   path: "/;/auth;/root",
 } as const;
 
-export const RequestNumberSchema = z.string().transform(parseNumber).optional();
+export const RequestNumberSchema = z.string().transform(parseNumber);

--- a/src/services/common/utils.ts
+++ b/src/services/common/utils.ts
@@ -1,0 +1,8 @@
+export const parseNumber = (value: string): number | undefined => {
+  const parsedNumberResult = Number(value);
+  if (isNaN(parsedNumberResult)) {
+    return undefined;
+  } else {
+    return parsedNumberResult;
+  }
+};

--- a/src/services/common/utils.ts
+++ b/src/services/common/utils.ts
@@ -1,7 +1,17 @@
-export const parseNumber = (value: string): number | undefined => {
+import { z } from "zod";
+
+export const parseNumber = (value: string): number => {
   const parsedNumberResult = Number(value);
   if (isNaN(parsedNumberResult)) {
-    return undefined;
+    throw new z.ZodError([
+      {
+        code: z.ZodIssueCode.invalid_type,
+        expected: "number",
+        received: "string",
+        path: [],
+        message: `Failed to parse [${value}] as a number`,
+      },
+    ]);
   } else {
     return parsedNumberResult;
   }


### PR DESCRIPTION
Creates a custom Zod transformer that fixes parsing of numbers from strings in request bodies or params.

Also note that a `ZodError` will be thrown if parsing the number fails.

Closes #9 