### PR TITLE
Make Price Immutabe Once Order Is Complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,15 @@ Open http://localhost:3000/ with your browser to see the result.
 - [X] Use snake_case for all DB columns (Untested across the board, unit tests would have been nice right now :-))
 - [ ] Return BAD REQUEST on failed Zod validations
 - [X] Add DB indexes
-- [ ] Improve logging with ts-log and create standard semantics for logs
-- [ ] For HTMX sections where we replace all content(hx-target="outerHTML"), would be a good practice to place these sections in constants sine they are referenced in multiple locations. Should we then choose to rename them, we'll then just need to change once reference (DRY)
+- [X] Improve logging with ts-log and create standard semantics for logs
+- [X] For HTMX sections where we replace all content(hx-target="outerHTML"), would be a good practice to place these sections in constants sine they are referenced in multiple locations. Should we then choose to rename them, we'll then just need to change once reference (DRY)
 - [ ] Ensure once order item added to an order, it's price is immutable
 - [ ] API tests
 - [ ] HTMX input white listing (Maybe important to avoid XSS attacks)
 - [ ] Timezone awareness
-- [ ] State machines for model statuses???
 - [ ] Proper handling of amounts with decimals
-- [ ] Fix bug with updated at not correctly propagating on DB level (a workaround is currently being used)
-- [ ] Remove hardcoding of base url
+- [X] Fix bug with updated at not correctly propagating on DB level (a workaround is currently being used). Was not working because updated_at on date functionality is only supported on Postgres for TypeORM. So the workaround is the solution.
+- [X] Remove hardcoding of base url
 
 ## Upcoming features
 - [X] Authentication (username & password) to prevent unauthorized access

--- a/public/htmx_debug.js
+++ b/public/htmx_debug.js
@@ -1,3 +1,5 @@
+htmx.logAll();
+
 htmx.defineExtension('debug', {
 	onEvent: function(name, evt) {
 		if (console.debug) {

--- a/src/components/pages/inventory/create_or_update_inventory_item.tsx
+++ b/src/components/pages/inventory/create_or_update_inventory_item.tsx
@@ -24,7 +24,7 @@ export const CreateOrUpdateInventoryComponent = (inventoryItem?: InventoryEntity
                         <input value={inventoryItem?.price.toString()} type="number" id="price" name="price" placeholder="Price" required />
                     </label>
                 </div>
-                <button id={HtmxTargets.INVENTORY_SUBMIT_RESULT_VIEW} type="submit" hx-post={inventoryItem === undefined ? "/inventory/create" : `/inventory/edit/{${inventoryItem.id}}`} hx-swap="outerHTML" hx-target={`#${HtmxTargets.INVENTORY_SUBMIT_RESULT_VIEW}`}>Submit</button>
+                <button id={HtmxTargets.INVENTORY_SUBMIT_RESULT_VIEW} type="submit" hx-post={inventoryItem === undefined ? "/inventory/create" : `/inventory/edit/${inventoryItem.id}`} hx-swap="outerHTML" hx-target={`#${HtmxTargets.INVENTORY_SUBMIT_RESULT_VIEW}`}>Submit</button>
             </form>
         </div>
     );

--- a/src/postgres/common/constants.ts
+++ b/src/postgres/common/constants.ts
@@ -6,13 +6,14 @@ export enum TableNames {
   PAYMENT = "payment",
   PAYMENT_TYPE = "payment_type",
   USERS = "users",
-  USER_CREDENTIALS = "user_credentials"
-};
+  USER_CREDENTIALS = "user_credentials",
+  ORDER_ITEM_PRICE = "order_item_price",
+}
 
 export enum PaymentTypes {
   CASH = "CASH",
-  MPESA = "MPESA"
-};
+  MPESA = "MPESA",
+}
 
 export enum OrderStatus {
   INITIALIZED = "INITIALIZED", // Goes into this state on creation of an order
@@ -24,5 +25,5 @@ export enum PaymentStatus {
   INITIALIZED = "INITIALIZED", // Goes into this state on creation of an order
   PAYMENT_PENDING = "PAYMENT_PENDING", // Not currently in use, but may be in the future for defer payments
   PARTIAL_PAYMENT = "PARTIAL_PAYMENT", // Also not in use at the moment, but for orders with partial payments
-  COMPLETED = "COMPLETED" // Full payment made
+  COMPLETED = "COMPLETED", // Full payment made
 }

--- a/src/postgres/entities/index.ts
+++ b/src/postgres/entities/index.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, JoinColumn, ManyToOne, OneToMany, OneToOne, PrimaryGeneratedColumn, Index } from "typeorm"
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany, OneToOne, PrimaryGeneratedColumn, Index, ManyToMany } from "typeorm"
 import { TableNames, OrderStatus, PaymentStatus, PaymentTypes } from "../common/constants"
 
 const generateIndexName = (tableName: TableNames, columnName: string): string => {
@@ -103,7 +103,26 @@ export class OrderItemEntity {
   @ManyToOne(() => OrdersEntity, (order) => order.order_items, { nullable: false })
   orders: OrdersEntity
 
+  @OneToOne(() => OrderPriceEntity, (orderPrice) => orderPrice.order_item)
+  order_item_price: OrderPriceEntity
+
   @Column("timestamptz", { nullable: false, default: () => "CURRENT_TIMESTAMP" })
+  created_at: Date
+}
+
+@Entity({name: TableNames.ORDER_ITEM_PRICE})
+export class OrderPriceEntity {
+  @PrimaryGeneratedColumn()
+  id: number
+
+  @OneToOne(() => OrderItemEntity, (orderItem) => orderItem.order_item_price, {nullable: false})
+  @JoinColumn()
+  order_item: OrderItemEntity 
+
+  @Column("decimal", {nullable: false })
+  price: number
+
+  @Column("timestamptz", {nullable: false, default: () => "CURRENT_TIMESTAMP"})
   created_at: Date
 }
 

--- a/src/postgres/index.ts
+++ b/src/postgres/index.ts
@@ -9,6 +9,7 @@ export class PostgresDataSourceSingleton {
   private constructor() {}
 
   public static async getInstance(): Promise<DataSource> {
+    console.log("Getting Postgres data source");
     if (!PostgresDataSourceSingleton.dataSource) {
       const dataSource = new DataSource({
         type: "postgres",
@@ -30,6 +31,7 @@ export class PostgresDataSourceSingleton {
           DatabaseEntities.PaymentEntity,
           DatabaseEntities.UsersEntity,
           DatabaseEntities.UserCredentialsEntity,
+          DatabaseEntities.OrderPriceEntity,
         ],
       });
 
@@ -41,7 +43,7 @@ export class PostgresDataSourceSingleton {
         throw new Error("Failed to initialize Postgres Datasource");
       }
     } else {
-      return PostgresDataSourceSingleton.getInstance();
+      return PostgresDataSourceSingleton.dataSource;
     }
   }
 }

--- a/src/postgres/queries/index.ts
+++ b/src/postgres/queries/index.ts
@@ -167,6 +167,7 @@ export const getOrderItemsInOrder = async (
 ): Promise<OrderItemEntity[]> => {
   return await dataSource.getRepository(OrderItemEntity).createQueryBuilder(TableNames.ORDER_ITEM)
     .innerJoinAndSelect("order_item.inventory", TableNames.INVENTORY)
+    .innerJoinAndSelect("order_item.order_item_price", TableNames.ORDER_ITEM_PRICE)
     .where("order_item.ordersId = :orderId", { orderId })
     .orderBy({ "order_item.id": "DESC" })
     .getMany();

--- a/src/postgres/queries/index.ts
+++ b/src/postgres/queries/index.ts
@@ -183,6 +183,7 @@ export const getUnfinishedOrderItems = async (
     .createQueryBuilder(TableNames.ORDERS)
     .innerJoinAndSelect("orders.order_items", TableNames.ORDER_ITEM)
     .innerJoinAndSelect("order_item.inventory", TableNames.INVENTORY)
+    .leftJoinAndSelect("order_item.order_item_price", TableNames.ORDER_ITEM_PRICE)
     .where("orders.status != :orderStatus", { orderStatus: OrderStatus.COMPLETED })
     .orderBy({ "orders.id": "DESC" })
     //.limit(10)

--- a/src/routes/inventory.ts
+++ b/src/routes/inventory.ts
@@ -73,7 +73,6 @@ export const inventoryRoutes = (dataSource: DataSource) => {
     })
     .post("/edit/:inventoryId", async (ctx) => {
       logger.info(ctx);
-      console.log(ctx);
       const validateResult = inventorySchemas.createInventoryItemBody.parse(
         ctx.body,
       );

--- a/src/routes/inventory.ts
+++ b/src/routes/inventory.ts
@@ -14,6 +14,7 @@ import {
 } from "../services/inventory";
 import { InventoryPage } from "../components/pages/inventory";
 import { RequestNumberSchema } from "../services/common/constants";
+import { logger } from "..";
 
 const inventorySchemas = {
   searchInventoryItemsQuery: z.object({
@@ -71,6 +72,8 @@ export const inventoryRoutes = (dataSource: DataSource) => {
       );
     })
     .post("/edit/:inventoryId", async (ctx) => {
+      logger.info(ctx);
+      console.log(ctx);
       const validateResult = inventorySchemas.createInventoryItemBody.parse(
         ctx.body,
       );

--- a/src/scripts/backfill_order_price.ts
+++ b/src/scripts/backfill_order_price.ts
@@ -1,9 +1,9 @@
 import { logger } from "..";
 import { PostgresDataSourceSingleton } from "../postgres";
 import {
-  getCompletedOrders,
   getOrderItemsInOrder,
   getOrderPrice,
+  getOrders,
   insertOrderPrice,
 } from "../postgres/queries";
 
@@ -18,7 +18,7 @@ const dataSource = await PostgresDataSourceSingleton.getInstance();
 
 const runOrderPriceBackFill = async () => {
   logger.trace("Start order price backfill");
-  const orders = await getCompletedOrders(dataSource);
+  const orders = await getOrders(dataSource);
 
   logger.info("Number of completed orders:", orders.length);
 

--- a/src/scripts/backfill_order_price.ts
+++ b/src/scripts/backfill_order_price.ts
@@ -1,0 +1,49 @@
+import { logger } from "..";
+import { PostgresDataSourceSingleton } from "../postgres";
+import {
+  getCompletedOrders,
+  getOrderItemsInOrder,
+  getOrderPrice,
+  insertOrderPrice,
+} from "../postgres/queries";
+
+/**
+ * This one-off script is required in order to backfill any already created orders into the
+ * order_item_price table.
+ *
+ * Uses the current inventory price of the item to set its amount.
+ */
+
+const dataSource = await PostgresDataSourceSingleton.getInstance();
+
+const runOrderPriceBackFill = async () => {
+  logger.trace("Start order price backfill");
+  const orders = await getCompletedOrders(dataSource);
+
+  logger.info("Number of completed orders:", orders.length);
+
+  orders.forEach(async (order) => {
+    const orderItems = await getOrderItemsInOrder(dataSource, order.id);
+    logger.info("orderItems", orderItems);
+
+    orderItems.forEach(async (orderItem) => {
+      // Fetch order price first to ensure it doesn't exist yet
+      const orderPrice = await getOrderPrice(dataSource, orderItem.id);
+      logger.info("orderPrice", orderPrice);
+
+      if (orderPrice === null) {
+        logger.info("Inserting into order_item_price table", {
+          orderItemId: orderItem.id,
+          price: orderItem.inventory.price,
+        });
+        await insertOrderPrice(
+          dataSource,
+          orderItem.id,
+          orderItem.inventory.price,
+        );
+      }
+    });
+  });
+};
+
+await runOrderPriceBackFill();

--- a/src/services/common/index.ts
+++ b/src/services/common/index.ts
@@ -7,6 +7,7 @@
 import { setTimeout } from "timers/promises";
 
 import { OrdersEntity, OrderItemEntity } from "../../postgres/entities";
+import { logger } from "../..";
 
 /**
  * Ensure when calling this funtion, the query for fetching order item entities should
@@ -16,12 +17,14 @@ import { OrdersEntity, OrderItemEntity } from "../../postgres/entities";
  * TODO: What if an order is unfinshed and the price changes in the inventory list? We need to handle that as well.
  */
 export const getTotalOrderCost = (orderItems: OrderItemEntity[]): number => {
+  logger.trace("orderItems on getTotalOrderCost", orderItems);
   if (orderItems.length === 0) {
     return 0;
   } else {
     let totalCost = 0;
     orderItems.forEach((item) => {
-      totalCost += item.quantity * item.inventory.price;
+      logger.trace("individual order item on getTotalOrderCost", item);
+      totalCost += item.quantity * item.order_item_price.price;
     });
     return totalCost;
     // above forEach can be further simplified with reduce call

--- a/src/services/inventory/index.ts
+++ b/src/services/inventory/index.ts
@@ -37,7 +37,25 @@ export const updateInventoryItem = async (
   inventoryId: number,
   name: string,
   price: number,
-) => {};
+) => {
+  logger.trace("Update inventory item endpoint called", {
+    inventoryId,
+    name,
+    price,
+  });
+  const inventoryItem = await queries.getInventoryItemById(
+    dataSource,
+    inventoryId,
+  );
+  if (inventoryItem === null) {
+    const message = `Inventory item with id [${inventoryId}] not found`;
+    logger.warn(message);
+    throw new Error(message);
+  } else {
+    await queries.updateInventoryItem(dataSource, inventoryId, { name, price });
+    return "Updated";
+  }
+};
 
 export const listInventoryItems = async (dataSource: DataSource) => {
   const result = await queries.getInventoryItems(dataSource);

--- a/src/services/payments/index.ts
+++ b/src/services/payments/index.ts
@@ -1,8 +1,10 @@
 import { DataSource } from "typeorm";
 import { PaymentsListComponent } from "../../components/pages/payments/payments_list";
 import { getCompletedOrders } from "../../postgres/queries";
+import { logger } from "../..";
 
 export const listPayments = async (dataSource: DataSource) => {
   const completedOrders = await getCompletedOrders(dataSource);
+  logger.trace("completedOrders", completedOrders);
   return PaymentsListComponent(completedOrders);
 };


### PR DESCRIPTION
Before, changing the inventory item's price would also change the price of an already completed order. This fixes that by creating `order_item_price` table that stores the price of the item on completion. That is then used as the reference when checking the price of the completed order.

- [X] Backfill already completed orders into the `order_item_price` table
- [x] Store into `order_item_price` table once an order is completed

Closes #15 